### PR TITLE
Fix for ambuguous reference to System.String

### DIFF
--- a/src/impl/ClassDescriptor.cs
+++ b/src/impl/ClassDescriptor.cs
@@ -508,6 +508,13 @@ namespace Volante.Impl
                         {
                             if (cls != null)
                             {
+                                if (cls == t)
+                                {
+                                    // Fix for ambuguous reference to System.String
+                                    // Since that class is "contained" in both mscorlib.dll and System.Runtime.dll,
+                                    // but they point towards the same type.
+                                    continue;
+                                }
                                 throw new DatabaseException(DatabaseException.ErrorCode.AMBIGUITY_CLASS, name);
                             }
                             else


### PR DESCRIPTION
For some reason, when loading both mscorlib.dll and System.Runtime.dll,
checking for ambiguous types will produce two results for System.String.
Since System.Runtime.dll only implements type forwards afaik,
the resulting type is the same - as confirmed by debugging.

This can be solved by using a simple == check on the loaded type, as the
type instance contains a reference to the assembly it stems from.